### PR TITLE
Remove original wait for Console token logic from api.

### DIFF
--- a/client/src/api/vehicles.ts
+++ b/client/src/api/vehicles.ts
@@ -1,21 +1,9 @@
 import { AxiosRequestConfig } from 'axios';
-import { sharedAccessBundle } from 'header/AuthenticatedHeader';
 import { axiosInstance } from 'header/httpClient';
-import { firstValueFrom } from 'rxjs';
 
 import { getUxDateDisplay } from '../utils/dates';
 
-const isTokenLoaded = async (): Promise<void> => {
-  const bundle = sharedAccessBundle;
-
-  await firstValueFrom(bundle);
-
-  return;
-};
-
 export const getVehicles = async (): Promise<VehicleDisplay[]> => {
-  await isTokenLoaded();
-
   const req: AxiosRequestConfig = {
     url: `${process.env.REACT_APP_BASE_URL}/api/vehicles`,
     method: 'get',


### PR DESCRIPTION
I had accidentally left this code in place, but it is superseded by the `ConsoleUIProvider`.