### PR TITLE
AB#9440 Upgrade ConsoleUI header to use version with Axios fix

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,25 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug Server App",
+      "args": ["${workspaceFolder}/server/src/main.ts"],
+      "runtimeArgs": [
+        "--nolazy",
+        "-r",
+        "ts-node/register",
+        "-r",
+        "tsconfig-paths/register"
+      ],
+      "sourceMaps": true,
+      "envFile": "${workspaceFolder}/server/.env",
+      "cwd": "${workspaceRoot}/server",
+      "console": "integratedTerminal"
+    }
+  ]
+}

--- a/client/package.json
+++ b/client/package.json
@@ -16,7 +16,7 @@
     "@types/react-dom": "^18.0.0",
     "@types/react-fontawesome": "^1.6.5",
     "axios": "^1.2.1",
-    "consoleui-library": "^1.1.9",
+    "consoleui-library": "^1.1.13",
     "craco-module-federation": "^1.1.0",
     "dayjs": "^1.11.7",
     "flowbite": "^1.5.5",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -3664,10 +3664,10 @@ connect-history-api-fallback@^2.0.0:
   resolved "https://registry.yarnpkg.com/connect-history-api-fallback/-/connect-history-api-fallback-2.0.0.tgz#647264845251a0daf25b97ce87834cace0f5f1c8"
   integrity sha512-U73+6lQFmfiNPrYbXqr6kZ1i1wiRqXnp2nhMsINseWXO8lDau0LGEffJ8kQi4EjLZympVgRdvqjAgiZ1tgzDDA==
 
-consoleui-library@^1.1.9:
-  version "1.1.9"
-  resolved "https://registry.yarnpkg.com/consoleui-library/-/consoleui-library-1.1.9.tgz#1a195a00bf0b0b14cc6fee812a5205eeb8799444"
-  integrity sha512-qNEntteaS7T1aW0W3GMyDS+O82XcII189Sk6uxLSt49uSNDQ1izcqe+f2vJ5ukOwmc4jV5N/IfoE8AdvvHj+aA==
+consoleui-library@^1.1.13:
+  version "1.1.13"
+  resolved "https://registry.yarnpkg.com/consoleui-library/-/consoleui-library-1.1.13.tgz#503f82e6da58a0f6caf7ae80dd23fce525a850e2"
+  integrity sha512-1SkE1ZYMlnOIdeGhIYTvTomlrRbpkzKOUIaH1t9kLJOoENR2gSbjQxcVCu0R2pW5dZyO6ozm5kaBM4EvM4ltMA==
   dependencies:
     "@babel/preset-env" "^7.18.10"
     "@testing-library/jest-dom" "^5.16.4"


### PR DESCRIPTION
**Changes**:
* The previous version of ConsoleUI (1.1.9) used an AxiosInstance implementation that swallowed errors. This led to http errors not being properly handled in the vehicle app. A fix was implemented in ConsoleUI 1.1.13 and this PR upgrades to that fix.
* Adds a VS Code launch.json file for debugging the server app.