### PR TITLE
AB#9441 Extract and pass through client auth headers

### DIFF
--- a/server/src/common/models/client.auth.headers.model.ts
+++ b/server/src/common/models/client.auth.headers.model.ts
@@ -1,0 +1,9 @@
+export interface ClientHeaders {
+  [key: string]: string;
+}
+
+export interface ClientAuthHeaders {
+  x_coreos_request_id: string;
+  x_coreos_tid: string;
+  x_coreos_access: string;
+}


### PR DESCRIPTION
**Change Description**
This PR makes a distinction between auth headers build with the app admin token and those received from client calls. For app init, it uses the app admin token, but for all pass-through calls for client, it uses the client token (which ultimately is obtained from ConsoleUI).